### PR TITLE
update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Limitations:
 You need to have Golang installed, otherwise follow the guide at [https://golang.org/doc/install](https://golang.org/doc/install).
 
 ```
-go get github.com/cornelk/goscrape
+go install github.com/cornelk/goscrape@latest
 ```
 
 ## Usage


### PR DESCRIPTION
if you try to run the project with  `go get github.com/cornelk/goscrape`  in go > 17 it returns the following error
```
 go get github.com/cornelk/goscrape
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.

```

this PR update the documentation based on the new golang installation.