### PR TITLE
add user agent argument support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ goscrape http://website.com
 ```
 Scrape a website and create an offline browsable version on the disk.
 
-Usage: goscrape [--include INCLUDE] [--exclude EXCLUDE] [--output OUTPUT] [--depth DEPTH] [--imagequality IMAGEQUALITY] [--timeout TIMEOUT] [--proxy PROXY] [--user USER] [--verbose] URLS [URLS ...]
+Usage: goscrape [--include INCLUDE] [--exclude EXCLUDE] [--output OUTPUT] [--depth DEPTH] [--imagequality IMAGEQUALITY] [--timeout TIMEOUT] [--proxy PROXY] [--user USER] [--useragent USERAGENT] [--verbose] URLS [URLS ...]
 
 Positional arguments:
   URLS
@@ -71,6 +71,8 @@ Options:
   --proxy PROXY, -p PROXY
                          HTTP proxy to use for scraping
   --user USER, -u USER   user[:password] to use for authentication
+  --useragent USERAGENT, -a USERAGENT 
+                         user agent to use for scraping
   --verbose, -v          verbose output
   --help, -h             display this help and exit
 ```

--- a/main.go
+++ b/main.go
@@ -23,8 +23,9 @@ type arguments struct {
 	ImageQuality int64 `arg:"-i,--imagequality" help:"image quality, 0 to disable reencoding"`
 	Timeout      int64 `arg:"-t,--timeout" help:"time limit in seconds for each HTTP request to connect and read the request body"`
 
-	Proxy string `arg:"-p,--proxy" help:"HTTP proxy to use for scraping"`
-	User  string `arg:"-u,--user" help:"user[:password] to use for authentication"`
+	Proxy     string `arg:"-p,--proxy" help:"HTTP proxy to use for scraping"`
+	User      string `arg:"-u,--user" help:"user[:password] to use for authentication"`
+	UserAgent string `arg:"-a,--useragent" help:"user agent to use for scraping"`
 
 	Verbose bool `arg:"-v,--verbose" help:"verbose output"`
 }
@@ -76,6 +77,7 @@ func run(args arguments) error {
 		OutputDirectory: args.Output,
 		Username:        username,
 		Password:        password,
+		UserAgent:       args.UserAgent,
 		Proxy:           args.Proxy,
 	}
 

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -31,7 +31,8 @@ type Config struct {
 	Username        string
 	Password        string
 
-	Proxy string
+	UserAgent string
+	Proxy     string
 }
 
 // Scraper contains all scraping data.
@@ -83,8 +84,12 @@ func New(logger *log.Logger, cfg Config) (*Scraper, error) {
 		u.Scheme = "http" // if no URL scheme was given default to http
 	}
 
+	if cfg.UserAgent == "" {
+		cfg.UserAgent = agent.GoogleBot()
+	}
+
 	b := surf.NewBrowser()
-	b.SetUserAgent(agent.GoogleBot())
+	b.SetUserAgent(cfg.UserAgent)
 	b.SetTimeout(time.Duration(cfg.Timeout) * time.Second)
 
 	if cfg.Proxy != "" {


### PR DESCRIPTION
Hi,

First of all, thanks for this project! After using this tool, I experienced that in some cases, being able to pass a custom user agent would give this tool extra flexibility.

I added another argument `--useragent` so that agent can be changed without going through the code.

Example usage:
`goscrape examplesite.com --useragent "Mozilla/5.0 (Windows NT 5.1; rv:7.0.1) Gecko/20100101 Firefox/7.0.1"`