### PR TITLE
Fixed #58 with a page detection issue

### DIFF
--- a/scraper/download.go
+++ b/scraper/download.go
@@ -73,8 +73,9 @@ func (s *Scraper) downloadAsset(ctx context.Context, u *url.URL, processor asset
 		return nil
 	}
 
-	filePath := s.getFilePath(u, false)
+	filePath := s.getFilePath(u)
 	if s.fileExists(filePath) {
+		s.logger.Warn(fmt.Sprintf("Asset %s already exists at %s", urlFull, filePath))
 		return nil
 	}
 

--- a/scraper/fileutil.go
+++ b/scraper/fileutil.go
@@ -13,11 +13,8 @@ const (
 )
 
 // getFilePath returns a file path for a URL to store the URL content in.
-func (s *Scraper) getFilePath(url *url.URL, isAPage bool) string {
-	fileName := url.Path
-	if isAPage {
-		fileName = getPageFilePath(url)
-	}
+func (s *Scraper) getFilePath(url *url.URL) string {
+	fileName := getPageFilePath(url)
 
 	var externalHost string
 	if url.Host != s.URL.Host {

--- a/scraper/fileutil_test.go
+++ b/scraper/fileutil_test.go
@@ -38,7 +38,7 @@ func TestGetFilePath(t *testing.T) {
 		URL, err := url.Parse(fix.DownloadURL)
 		require.NoError(t, err)
 
-		output := s.getFilePath(URL, true)
+		output := s.getFilePath(URL)
 		assert.Equal(t, fix.ExpectedFilePath, output)
 	}
 }

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -253,7 +253,6 @@ func (s *Scraper) processURL(ctx context.Context, u *url.URL, currentDepth uint)
 func (s *Scraper) storeDownload(u *url.URL, data []byte, doc *html.Node,
 	index *htmlindex.Index, fileExtension string) {
 
-	isAPage := false
 	if fileExtension == "" {
 		fixed, hasChanges, err := s.fixURLReferences(u, doc, index)
 		if err != nil {
@@ -266,11 +265,11 @@ func (s *Scraper) storeDownload(u *url.URL, data []byte, doc *html.Node,
 		if hasChanges {
 			data = fixed
 		}
-		isAPage = true
 	}
 
-	filePath := s.getFilePath(u, isAPage)
+	filePath := s.getFilePath(u)
 	// always update html files, content might have changed
+	s.logger.Debug(fmt.Sprintf("Writing file to %s", filePath))
 	if err := s.fileWriter(filePath, data); err != nil {
 		s.logger.Error("Writing to file failed",
 			log.String("URL", u.String()),


### PR DESCRIPTION
Fixes this issue by allowing the `getPageFilePath()` to always run against all assets, and allows it to determine if it needs to add the `.html` extension or not based on the construction of the URL.